### PR TITLE
Fix MongoDB replica set authentication for transaction support

### DIFF
--- a/config/mongodb/init-replica.sh
+++ b/config/mongodb/init-replica.sh
@@ -1,0 +1,36 @@
+﻿#!/bin/bash
+echo "🔧 Initializing MongoDB Replica Set..."
+
+# Wait for MongoDB to be ready
+echo "⏳ Waiting for MongoDB to start..."
+until mongosh --host mongodb:27017 --eval "print('MongoDB is ready')" > /dev/null 2>&1; do
+    sleep 2
+done
+
+echo "📋 Configuring replica set..."
+
+# Initialize replica set WITH AUTHENTICATION
+mongosh --host mongodb:27017 -u admin -p secure_mongo_password_123 --authenticationDatabase admin --eval "
+try {
+    rs.status();
+    print('Replica set already initialized');
+} catch(e) {
+    print('Initializing replica set...');
+    rs.initiate({
+        _id: 'rs0',
+        members: [
+            { _id: 0, host: 'mongodb:27017' }
+        ]
+    });
+    
+    // Wait for replica set to be ready
+    while(rs.status().myState != 1) {
+        print('Waiting for replica set primary...');
+        sleep(1000);
+    }
+    
+    print('Replica set initialized successfully');
+}
+"
+
+echo "✅ MongoDB replica set setup complete!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,11 +50,19 @@ services:
       - "27017:27017"
     volumes:
       - mongodb-data:/data/db
+      - ./config/mongodb/mongo-keyfile:/tmp/mongo-keyfile:ro
     networks:
       - muscledia-network
-    command: mongod --auth --bind_ip_all
+    entrypoint: >
+      bash -c "
+        mkdir -p /opt/keyfile &&
+        cp /tmp/mongo-keyfile /opt/keyfile/mongo-keyfile &&
+        chmod 600 /opt/keyfile/mongo-keyfile &&
+        chown mongodb:mongodb /opt/keyfile/mongo-keyfile &&
+        exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile /opt/keyfile/mongo-keyfile
+      "
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')" ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -206,14 +214,14 @@ services:
       SPRING_PROFILES_ACTIVE: docker
       SERVER_PORT: 8082
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://service-discovery:8761/eureka
-      SPRING_DATA_MONGODB_URI: mongodb://admin:secure_mongo_password_123@mongodb:27017/muscledia_workouts?authSource=admin
+      SPRING_DATA_MONGODB_URI: mongodb://admin:secure_mongo_password_123@mongodb:27017/muscledia_workouts?authSource=admin&replicaSet=rs0
       JWT_SECRET: 81795ad725b2cadd49d27a60438415588db374020a561ae19cafebeef6339655304975b150867b21d3715e341a49271a75a7dde39776e156af0ddad50f5e6ec3
       USER_SERVICE_URL: http://user-service:8081
     ports:
       - "8082:8082"
     depends_on:
-      mongodb:
-        condition: service_healthy
+      mongodb-setup:
+        condition: service_completed_successfully
       service-discovery:
         condition: service_healthy
     networks:
@@ -235,14 +243,14 @@ services:
       SPRING_PROFILES_ACTIVE: docker
       SERVER_PORT: 8083
       EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://service-discovery:8761/eureka
-      SPRING_DATA_MONGODB_URI: mongodb://admin:secure_mongo_password_123@mongodb:27017/gamification_db?authSource=admin
+      SPRING_DATA_MONGODB_URI: mongodb://admin:secure_mongo_password_123@mongodb:27017/gamification_db?authSource=admin&replicaSet=rs0
       JWT_SECRET: 81795ad725b2cadd49d27a60438415588db374020a561ae19cafebeef6339655304975b150867b21d3715e341a49271a75a7dde39776e156af0ddad50f5e6ec3
       USER_SERVICE_URL: http://user-service:8081
     ports:
       - "8083:8083"
     depends_on:
-      mongodb:
-        condition: service_healthy
+      mongodb-setup:
+        condition: service_completed_successfully
       service-discovery:
         condition: service_healthy
     networks:
@@ -278,8 +286,27 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
-    volumes:
-      - ./config/mongodb/init-replica.sh:/init-replica.sh
-    entrypoint: [ "bash", "/init-replica.sh" ]
+    command: >
+      bash -c "
+        echo 'Waiting for MongoDB...' &&
+        until mongosh --host mongodb:27017 --eval 'print(\"ready\")' > /dev/null 2>&1; do sleep 2; done &&
+        echo 'Initializing replica set...' &&
+        mongosh --host mongodb:27017 -u admin -p secure_mongo_password_123 --authenticationDatabase admin --eval '
+        try {
+          rs.status();
+          print(\"Replica set already initialized\");
+        } catch(e) {
+          rs.initiate({
+            _id: \"rs0\",
+            members: [{ _id: 0, host: \"mongodb:27017\" }]
+          });
+          while(rs.status().myState !== 1) { 
+            print(\"Waiting for primary...\"); 
+            sleep(1000); 
+          }
+          print(\"Replica set initialized\");
+        }' &&
+        echo 'Setup complete!'
+      "
     networks:
       - muscledia-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - mongodb-data:/data/db
     networks:
       - muscledia-network
+    command: mongod --auth --bind_ip_all
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 30s
@@ -267,5 +268,18 @@ services:
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - api-gateway
+    networks:
+      - muscledia-network
+
+
+  mongodb-setup:
+    image: mongo:6.0
+    container_name: muscledia-mongodb-setup
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    volumes:
+      - ./config/mongodb/init-replica.sh:/init-replica.sh
+    entrypoint: [ "bash", "/init-replica.sh" ]
     networks:
       - muscledia-network

--- a/scripts/fix-mongodb-setup.sh
+++ b/scripts/fix-mongodb-setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# scripts/verify-mongodb.sh
+
+echo "🔍 Verifying MongoDB Replica Set Setup..."
+echo ""
+
+# Check if MongoDB container is running
+if ! docker ps | grep -q "muscledia-mongodb.*Up"; then
+    echo "❌ MongoDB container is not running"
+    echo "   Run: docker-compose up -d mongodb"
+    exit 1
+fi
+
+echo "✅ MongoDB container is running"
+
+# Test MongoDB connection
+echo "🔗 Testing MongoDB connection..."
+if docker exec muscledia-mongodb mongosh -u admin -p secure_mongo_password_123 --authenticationDatabase admin --eval "print('Connection successful')" > /dev/null 2>&1; then
+    echo "✅ MongoDB authentication working"
+else
+    echo "❌ MongoDB authentication failed"
+    exit 1
+fi
+
+# Check replica set status
+echo "📋 Checking replica set status..."
+REPLICA_STATUS=$(docker exec muscledia-mongodb mongosh -u admin -p secure_mongo_password_123 --authenticationDatabase admin --quiet --eval "
+try {
+    var status = rs.status();
+    if (status.myState === 1) {
+        print('PRIMARY');
+    } else {
+        print('NOT_PRIMARY');
+    }
+} catch(e) {
+    print('NOT_INITIALIZED');
+}
+")
+
+case $REPLICA_STATUS in
+    "PRIMARY")
+        echo "✅ Replica set is initialized and this node is PRIMARY"
+        ;;
+    "NOT_PRIMARY")
+        echo "⚠️  Replica set is initialized but this node is not PRIMARY"
+        ;;
+    "NOT_INITIALIZED")
+        echo "❌ Replica set is not initialized"
+        echo "   Run the initialization script: docker-compose up mongodb-setup"
+        exit 1
+        ;;
+    *)
+        echo "❓ Unknown replica set status: $REPLICA_STATUS"
+        ;;
+esac
+
+# Test database operations
+echo "📝 Testing database operations..."
+if docker exec muscledia-mongodb mongosh -u admin -p secure_mongo_password_123 --authenticationDatabase admin --quiet --eval "
+use muscledia_workouts;
+db.test.insertOne({test: 'verification', timestamp: new Date()});
+var count = db.test.countDocuments({test: 'verification'});
+db.test.deleteMany({test: 'verification'});
+print('Test operations: ' + (count > 0 ? 'SUCCESS' : 'FAILED'));
+" | grep -q "SUCCESS"; then
+    echo "✅ Database operations working"
+else
+    echo "❌ Database operations failed"
+    exit 1
+fi
+
+# Check connection strings
+echo ""
+echo "🔗 Connection String Verification:"
+echo "   MongoDB URI: mongodb://admin:secure_mongo_password_123@mongodb:27017/muscledia_workouts?authSource=admin&replicaSet=rs0"
+
+# Test from application perspective
+echo ""
+echo "🚀 Testing application database connections..."
+
+# Check if services can connect to MongoDB
+if docker-compose logs workout-service 2>/dev/null | grep -q "Started.*WorkoutService"; then
+    echo "✅ Workout Service connected to MongoDB"
+elif docker-compose logs workout-service 2>/dev/null | grep -qi "error.*mongo"; then
+    echo "❌ Workout Service has MongoDB connection issues"
+    echo "   Check logs: docker-compose logs workout-service"
+else
+    echo "⏳ Workout Service may still be starting up"
+fi
+
+if docker-compose logs gamification-service 2>/dev/null | grep -q "Started.*GamificationService"; then
+    echo "✅ Gamification Service connected to MongoDB"
+elif docker-compose logs gamification-service 2>/dev/null | grep -qi "error.*mongo"; then
+    echo "❌ Gamification Service has MongoDB connection issues"
+    echo "   Check logs: docker-compose logs gamification-service"
+else
+    echo "⏳ Gamification Service may still be starting up"
+fi
+
+echo ""
+echo "🎉 MongoDB verification complete!"
+echo ""
+echo "📊 Additional commands for troubleshooting:"
+echo "   View replica set status: docker exec -it muscledia-mongodb mongosh -u admin -p secure_mongo_password_123 --authenticationDatabase admin --eval 'rs.status()'"
+echo "   View MongoDB logs: docker-compose logs mongodb"
+echo "   View service logs: docker-compose logs workout-service gamification-service"
+echo "   Restart MongoDB: docker-compose restart mongodb"

--- a/scripts/setup-mongodb-keyfile.ps1
+++ b/scripts/setup-mongodb-keyfile.ps1
@@ -1,0 +1,72 @@
+# MongoDB Keyfile Setup Script for Windows
+# Generates a secure keyfile for MongoDB replica set authentication
+
+Write-Host "Creating MongoDB keyfile..." -ForegroundColor Green
+
+try {
+    # Create directory
+    Write-Host "Creating config directory..." -ForegroundColor Yellow
+    New-Item -ItemType Directory -Force -Path .\config\mongodb | Out-Null
+
+    # Generate secure random keyfile
+    Write-Host "Generating secure 756-byte keyfile..." -ForegroundColor Yellow
+    $bytes = New-Object byte[] 756
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    $rng.GetBytes($bytes)
+    $base64 = [Convert]::ToBase64String($bytes)
+
+    # Write keyfile
+    $keyfilePath = ".\config\mongodb\mongo-keyfile"
+    $base64 | Out-File -FilePath $keyfilePath -Encoding ASCII -NoNewline
+    $rng.Dispose()  # Clean up RNG
+
+    # Verify file was created
+    if (-not (Test-Path $keyfilePath)) {
+        throw "Failed to create keyfile"
+    }
+
+    # Set strict permissions (equivalent to chmod 600)
+    Write-Host "Setting restrictive file permissions..." -ForegroundColor Yellow
+    $resolvedPath = Resolve-Path $keyfilePath
+    $acl = Get-Acl $resolvedPath
+
+    # Disable inheritance and remove existing permissions
+    $acl.SetAccessRuleProtection($true, $false)
+    $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) | Out-Null }
+
+    # Add read/write for current user only
+    $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $permission = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $currentUser,
+        "Read,Write",
+        "Allow"
+    )
+    $acl.AddAccessRule($permission)
+    Set-Acl -Path $resolvedPath -AclObject $acl
+
+    # Verify keyfile size and content
+    $fileInfo = Get-Item $resolvedPath
+    $content = Get-Content $resolvedPath -Raw
+
+    Write-Host "`nKeyfile created successfully!" -ForegroundColor Green
+    Write-Host "Location: $resolvedPath" -ForegroundColor Cyan
+    Write-Host "Size: $($fileInfo.Length) characters" -ForegroundColor Cyan
+    Write-Host "Preview (first 50 chars): $($content.Substring(0, [Math]::Min(50, $content.Length)))..." -ForegroundColor Cyan
+
+    # Verify permissions
+    Write-Host "`nFile permissions:" -ForegroundColor Cyan
+    $acl = Get-Acl $resolvedPath
+    foreach ($access in $acl.Access) {
+        Write-Host "  $($access.IdentityReference): $($access.FileSystemRights)" -ForegroundColor Gray
+    }
+
+    Write-Host "`nNext steps:" -ForegroundColor Yellow
+    Write-Host "1. Update docker-compose.yml to mount this keyfile" -ForegroundColor White
+    Write-Host "2. Add --keyFile parameter to MongoDB command" -ForegroundColor White
+    Write-Host "3. Initialize replica set with mongodb-setup service" -ForegroundColor White
+
+} catch {
+    Write-Host "`nError creating keyfile: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "Make sure you have write permissions to the current directory" -ForegroundColor Yellow
+    exit 1
+}


### PR DESCRIPTION
### Problem
MongoDB was running in standalone mode, causing `MongoQueryException: Transaction numbers are only allowed on a replica set member or mongos` errors in the workout service. This prevented proper transaction handling for critical operations.

### Solution
- Configure MongoDB as an authenticated replica set (rs0) with keyFile security
- Add automated keyfile generation with proper Windows-to-Docker permission handling
- Implement replica set initialization service with authentication
- Update service connection strings to include `replicaSet=rs0` parameter
- Fix Docker entrypoint to handle keyfile permissions in Linux containers

### Changes
- **docker-compose.yml**: Added keyFile mount, custom entrypoint for permission handling, and mongodb-setup service
- **setup-mongodb-keyfile.ps1**: Windows script for secure keyfile generation
- **init-replica.sh**: Automated replica set initialization with auth
- **Service configs**: Updated MongoDB URIs to include replica set parameter

### Impact
- ✅ MongoDB transactions now work correctly
- ✅ Workout service operations complete without errors  
- ✅ Proper authentication and security for replica set
- ✅ Automated setup process for development environment

**Resolves**: Transaction failures in workout and gamification services
**Testing**: All services start successfully, MongoDB transactions validated